### PR TITLE
Use async database reader

### DIFF
--- a/DataCore/Reader/Reader.cs
+++ b/DataCore/Reader/Reader.cs
@@ -37,11 +37,12 @@ namespace _4Time.DataCore
                     await connection.OpenAsync();
                     using (var command = new SqlCommand(sql.ToString(), connection))
                     {
-                        using (var dbReader = command.ExecuteReader())
+                        // Verwende die asynchrone Variante, um Threadpool-Blockierungen zu vermeiden
+                        using (var dbReader = await command.ExecuteReaderAsync())
                         {
                             while (await dbReader.ReadAsync())
                             {
-                                await semaphore.WaitAsync(); 
+                                await semaphore.WaitAsync();
 
                                 var rowData = ExtractRowDataForProcessing(dbReader, typeof(T), properties);
 


### PR DESCRIPTION
## Summary
- avoid blocking threads by using `SqlCommand.ExecuteReaderAsync`

## Testing
- `apt-get update`
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f390ade883279f05ab9db19c05b6